### PR TITLE
Deliberately break the badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > **Make sure you update the links for the badges below so they point
 > to _your_ project and not the "starter" copy. You also need to make
 > sure that analysis checks are being run on all pull requests.** See
-> [`CODE-QUALITY-CHECKS.md`](CODE-QUALITY-CHECKS.md)
+> [`CODE_QUALITY_CHECKS.md`](CODE_QUALITY_CHECKS.md)
 > for info on how to do that.
 >
 > Feel free to remove the badge above and this text when you've

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 >
 > Feel free to remove the badge above and this text when you've
 > dealt with that.
+
 # CSCI 3601 Iteration Template <!-- omit in toc -->
 
 [![Server Build Status](../../actions/workflows/server.yml/badge.svg)](../../actions/workflows/server.yml)

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 [![Client Build Status](../../actions/workflows/client.yaml/badge.svg)](../../actions/workflows/client.yaml)
 [![End to End Build Status](../../actions/workflows/e2e.yaml/badge.svg)](../../actions/workflows/e2e.yaml)
 
-[![BCH compliance](https://bettercodehub.com/edge/badge/UMM-CSci-3601/3601-iteration-template?branch=main)](https://bettercodehub.com/)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/UMM-CSci-3601/3601-iteration-template.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/UMM-CSci-3601/3601-iteration-template/alerts/)
+[![BCH compliance](https://bettercodehub.com/edge/badge/UMM-CSci-3601-21/3601-iteration-template?branch=main)](https://bettercodehub.com/)
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/UMM-CSci-3601-21/3601-iteration-template.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/UMM-CSci-3601-S21/3601-iteration-template/alerts/)
 
 - [Development](#development)
   - [Common commands](#common-commands)


### PR DESCRIPTION
This deliberately breaks the badge URLs so it will be obvious when students haven't updated them.